### PR TITLE
Add suggestions URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "search_provider": {
       "name": "Brave",
       "search_url": "https://search.brave.com/search?q={searchTerms}",
+      "suggest_url": "https://search.brave.com/api/suggest?q={searchTerms}",
       "favicon_url": "https://brave.com/static-assets/images/brave-favicon.png",
       "keyword": "@brave"
     }


### PR DESCRIPTION
Add the search suggestions URL as described in [the OpenSearch spec](https://cdn.search.brave.com/serp/v1/static/brand/d68c1301af3c0e4522aa168aea207e3762d49450165231b9e480fc684b876d63-opensearch.xml).